### PR TITLE
Display minutes and seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,9 @@ This is a test application written in Python which keeps track of how much time 
 This has only been tested on Arch Linux 64bit. It should work on Mac, but probably will not work on Windows (because of the bash scripts and the curses library).
 
 * Python 3 [Get it here](https://www.python.org/getit/)
-* virtualenv. This allows packages to be installed local to a project. Run `./util.sh install_global_dependencies` to install it. This uses `sudo`, so feel free to take a look at the file before running it.
+* virtualenv. This allows packages to be installed local to a project. Run `./util.sh install_global_deps` to install it. This uses `sudo`, so feel free to take a look at the file before running it.
 
-All other dependencies are local to the project and can be installed by running `./util.sh install_local_dependencies`. For reference these are:
-
-* atomicwrites==1.1.5
-* attrs==18.1.0
-* mock==2.0.0
-* more-itertools==4.2.0
-* pbr==4.2.0
-* pluggy==0.6.0
-* py==1.5.4
-* pytest==3.6.3
-* six==1.11.0
+All other dependencies are local to the project and can be installed by running `./util.sh install_local_deps`. 
 
 ### virtualenv setup
 
@@ -31,10 +21,10 @@ If you did not install virtualenv from `util.sh` you will also need to set it up
 
 There are four commands
 
-./tasklog.py start [TASK_NAME]\
-./tasklog.py ls\
-./tasklog.py show [DATE]\
-./tasklog.py rm [DATE]\
+`./tasklog.py start [TASK_NAME]`\
+`./tasklog.py ls`\
+`./tasklog.py show [DATE]`\
+`./tasklog.py rm [DATE]`
 
 ### start
 

--- a/database.py
+++ b/database.py
@@ -318,7 +318,7 @@ class TaskData:
     """
     A simple class to hold data on a task.
     it has two properties:
-    name -- any reasonable string, naming a task
+    name -- a string, naming a task
     time -- an int for how long was spent on the task,
     in minutes
     """
@@ -326,9 +326,9 @@ class TaskData:
     def __init__(self, name, time):
 
         if not isinstance(name, str):
-            raise TypeError("TaskData constructor name argument should be a string")
-        if not isinstance(time, int):
-            raise TypeError("TaskData constructor time argument should be a positive int")
+            raise TypeError("TaskData name should be a string")
+        if not (isinstance(time, int) or isinstance(time, float)):
+            raise TypeError("TaskData time should be a number")
         if time < 0:
             raise ValueError("TaskData time should non-negative")
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,39 @@
+"""
+test_commands.py
+
+Tests for commands.py
+"""
+
+# core
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# project
+import commands
+
+def test_get_minutes_seconds():
+    # 67 seconds should equal ...
+    test_seconds = 67
+    # ... 1 minute 7 seconds
+    expected = (1, 7)
+    result = commands.get_minutes_seconds(test_seconds)
+
+    assert result == expected
+
+def test_make_time_string_sing():
+
+    test_seconds = 67
+    expected = "1 minute and 7 seconds"
+    result = commands.make_time_string(test_seconds)
+
+    assert result == expected
+
+def test_make_time_string_plural():
+
+    test_seconds = 127
+    expected = "2 minutes and 7 seconds"
+    result = commands.make_time_string(test_seconds)
+
+    assert result == expected

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -25,8 +25,8 @@ def test_init_directories(tmpdir):
 def test_connect(tmpdir):
 
     temp = tmpdir.mkdir("tmp")
-    new_dir = os.path.join(temp, 'new')
-    database.DATA_DIR = new_dir
+    database.DBNAME = os.path.join(temp, 'task.db')
+
     db = database.connect()
     assert type(db) is sqlite3.Connection
 


### PR DESCRIPTION
Originally I decided just to display the minutes taken on a task, the reasoning being that second precision is unnecessary information when track tasks throughout a day. However, because the timer only ticks up every minute it didn't look very responsive. This PR adds seconds to the timer in the format "X minutes and Y seconds" so that the clock looks like it is actually doing something. Minutes will not display until 1 minute has passed because "0 minutes" looks silly.

Also added better conditional clock text display, so if 1 minute has passed, it says 1 minute, not 1 minutes.

Also improved readme formatting.

Also removed HORRIBLE bug where the database test script was accessing the REAL database :(