### PR TITLE
provide a helpful error message if venv missing

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,8 +5,8 @@ set -eo pipefail
 function install
 {
     install_global_deps
-    install_local_deps
     setup_virtualenv
+    install_local_deps
 }
 
 function setup_virtualenv

--- a/tasklog.py
+++ b/tasklog.py
@@ -12,15 +12,20 @@ ls(a) -- handle ls command
 show(a) -- handle show command
 rm(a) -- handle rm command
 """
-
+# Python Core
+import sys
 import os
 # auto-run virtualenv
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 ACTIVATE = os.path.join(THIS_DIR, 'venv/bin/activate_this.py')
-exec(open(ACTIVATE).read())
-
-# Python Core
-import sys
+try:
+    exec(open(ACTIVATE).read())
+except FileNotFoundError as err:
+    # If file not found, it likely means virtualenv
+    # was never setup, so request user to run the 
+    # setup script
+    print("Please run ./setup.sh install")
+    sys.exit(1)
 
 # Third party
 import argparse


### PR DESCRIPTION
At the beginning of tasklog.py virtualenv is activated. If virtualenv was never setup, this will fail. This PR adds a message indicating what the user should do (run setup script)